### PR TITLE
fix: Day/Night/System selector is broken

### DIFF
--- a/src/components/ui/color-mode.tsx
+++ b/src/components/ui/color-mode.tsx
@@ -11,6 +11,8 @@ export const useColorMode = () => {
   const { theme, resolvedTheme, setTheme } = useTheme();
 
   const toggleColorMode = () => {
+    if (!theme || !resolvedTheme) return;
+
     if (theme === 'system') setTheme('light');
     else if (theme === 'light') setTheme('dark');
     else setTheme('system');

--- a/src/components/ui/components/Header/Header.tsx
+++ b/src/components/ui/components/Header/Header.tsx
@@ -1,6 +1,7 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
+import { useEffect, useState } from 'react';
 import { Box, Container, Heading, Flex, IconButton, Button } from '@chakra-ui/react';
 import { FiSun, FiMoon, FiMonitor } from 'react-icons/fi';
 import { LuUpload } from 'react-icons/lu';
@@ -15,8 +16,11 @@ interface HeaderProps {
 }
 
 export const Header = ({ title, actionButton }: HeaderProps) => {
+  const [mounted, setMounted] = useState(false);
   const { toggleColorMode, colorMode, theme } = useColorMode();
   const openUploadDialog = useResultsFileUploadDialog();
+
+  useEffect(() => setMounted(true), []);
 
   return (
     <Box bg="bg.section" borderBottom="1px solid" borderColor="border.main">
@@ -35,18 +39,20 @@ export const Header = ({ title, actionButton }: HeaderProps) => {
               Upload
             </Button>
           </Flex>
-          <IconButton
-            aria-label="Toggle theme"
-            onClick={toggleColorMode}
-            variant="ghost"
-            color={colorMode === 'light' ? 'black' : 'white'}
-            borderWidth="1px"
-            borderStyle="solid"
-            size="sm"
-            borderColor="border.subtle"
-          >
-            {theme === 'system' ? <FiSun /> : theme === 'light' ? <FiMoon /> : <FiMonitor />}
-          </IconButton>
+          {mounted && (
+            <IconButton
+              aria-label="Toggle theme"
+              onClick={toggleColorMode}
+              variant="ghost"
+              color={colorMode === 'light' ? 'black' : 'white'}
+              borderWidth="1px"
+              borderStyle="solid"
+              size="sm"
+              borderColor="border.subtle"
+            >
+              {theme === 'system' ? <FiMonitor /> : colorMode === 'light' ? <FiSun /> : <FiMoon />}
+            </IconButton>
+          )}
         </Flex>
       </Container>
     </Box>


### PR DESCRIPTION
Implemented:
```
Expected result:

Day should apply the Light theme.
Night should apply the Dark theme.
System should follow the device's current system theme (Light or Dark).
```