### PR TITLE
feat: add project-scoped Test Scenario catalog

### DIFF
--- a/openspec/changes/add-project-scoped-test-scenario-list/.openspec.yaml
+++ b/openspec/changes/add-project-scoped-test-scenario-list/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/add-project-scoped-test-scenario-list/design.md
+++ b/openspec/changes/add-project-scoped-test-scenario-list/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The client already centralizes authenticated API access in `baseApi`, generates endpoint types and hooks into `generatedApi.ts`, stores the selected project in the projects slice, and composes protected pages with `ProtectedRoute`, `ProjectGuard`, and `MainTemplate`. Navigation comes from `PATHS` and `navigationMenuConfig`, while a shared `Pagination` component implements page selection.
+
+The running backend OpenAPI document at `http://127.0.0.1:3001/api/openapi.json` defines an authenticated `GET /api/v2/test-scenarios` operation with required `projectId`, optional `page` and `limit`, and a paginated response.
+
+The generated API file may also reflect unrelated differences between the checked-in client contract and the running backend document. Implementation must keep the generated output exact while reviewing those differences rather than hand-editing generated declarations.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Integrate the current authenticated scenario-list operation through generated RTK Query code.
+- Fit the catalog into existing route, project selection, page-template, status, and pagination patterns.
+- Make project changes reset pagination synchronously and prevent stale cross-project records from rendering.
+- Keep the catalog compatible with the planned lightweight list response by consuming only stable summary fields.
+- Separate query/state ownership from presentational rendering so request behavior and visible states can be tested independently.
+
+**Non-Goals:**
+
+- Adding a temporary handwritten API endpoint or editing generated API declarations by hand.
+- Adding scenario detail navigation or any scenario mutation workflow.
+- Rendering, parsing, truncating, or caching Markdown specifically for catalog presentation.
+
+## Decisions
+
+### Generate the endpoint from the running OpenAPI document
+
+Run the existing generator with `RTK_QUERY_OPENAPI_URL=http://127.0.0.1:3001/api/openapi.json` so the Test Scenario hook and types use the same authenticated `baseApi` as other REST operations. Generated output remains wholly generator-owned, and an explicit contract test will pin the list arguments and metadata needed by the catalog.
+
+Alternative considered: inject a handwritten endpoint into `extendedApi`. This would avoid unrelated generated diff but would duplicate a documented endpoint and undermine issue #78's generated-contract requirement.
+
+### Use a page, query container, and presentational catalog view
+
+Add a Test Scenarios page under `src/pages/`, with feature code under `src/components/test-scenarios/`. The page supplies the standard template. A container obtains the selected project, owns page state, calls the generated query, and translates query state into explicit view props. A presentational view renders summaries and status states without access to Redux or RTK Query.
+
+Alternative considered: keep query logic and all state branches directly in the page. That is smaller in file count but makes project-switch and stale-data behavior harder to test and diverges from the repository's feature container/view patterns.
+
+### Reset state through selected-project identity
+
+Key the state-owning catalog container by `selectedProjectId`, with page state initialized to 1 inside that keyed boundary. A project change therefore creates a fresh page state before the new query is issued rather than relying on an effect that runs after an intermediate render. Pass `projectId`, `page`, and an explicit limit of 30 to the generated hook.
+
+Use the query result associated with the current arguments for rendering. During an argument change, the view shows the new request's loading state rather than retaining data from the old project. RTK Query's argument-keyed cache may still satisfy repeat visits, but only data keyed to the current project and page can render.
+
+Alternative considered: reset `page` in an effect that watches `selectedProjectId`. That can briefly issue a request for the new project using the old page and complicates the guarantee that the first new-project request is page 1.
+
+### Consume a deliberate summary projection in the view
+
+Map each API record to view data containing only `id`, `title`, `createdAt`, and `updatedAt`. The presentational view never receives `contentMd`. Dates use the repository's established human-readable formatting style, and scenario IDs provide stable render keys.
+
+Alternative considered: pass generated `TestScenario` objects directly to scenario cards. That is less code but allows catalog components to start depending on `contentMd` and couples presentation to the current oversized response.
+
+### Keep the list non-interactive beyond pagination
+
+Scenario rows/cards will not navigate or expose an affordance that implies detail support. The sidebar entry itself remains a normal link, matching existing navigation behavior. Detail navigation can be introduced with the separate CRUD/detail capability without changing the foundation route.
+
+## Risks / Trade-offs
+
+- [Generated output includes unrelated backend contract drift] → Review the generator diff, retain exact generated output, and use compile-time contract tests to surface incompatible changes before implementation proceeds.
+- [The API record contains fields the catalog does not present] → Map API records to explicit summary view data before rendering.
+- [A selected project changes while a request is in flight] → Key state by project identity and render only current-argument query data so late responses remain isolated in their own RTK Query cache entry.
+- [Zero-page responses use `totalPages: 0`] → Render pagination only when `totalPages > 1`; the empty state does not pass zero into an interactive paginator.
+
+## Migration Plan
+
+1. Regenerate the API from the running backend and review the generated contract diff.
+2. Add the path, guarded route, navigation entry, page, container, summary mapping, and view states.
+3. Add focused contract, navigation, route, catalog, pagination, and project-switch tests.
+4. Run the repository validation commands before delivery.
+
+Rollback consists of reverting the route/navigation and feature files together with the corresponding generated API update. No client-persisted data or backend migration is introduced by this change.

--- a/openspec/changes/add-project-scoped-test-scenario-list/design.md
+++ b/openspec/changes/add-project-scoped-test-scenario-list/design.md
@@ -12,6 +12,7 @@ The generated API file may also reflect unrelated differences between the checke
 
 - Integrate the current authenticated scenario-list operation through generated RTK Query code.
 - Fit the catalog into existing route, project selection, page-template, status, and pagination patterns.
+- Present scenario summaries in a compact table with fixed **Title**, **Created**, and **Updated** columns.
 - Make project changes reset pagination synchronously and prevent stale cross-project records from rendering.
 - Keep the catalog compatible with the planned lightweight list response by consuming only stable summary fields.
 - Separate query/state ownership from presentational rendering so request behavior and visible states can be tested independently.
@@ -30,15 +31,15 @@ Run the existing generator with `RTK_QUERY_OPENAPI_URL=http://127.0.0.1:3001/api
 
 Alternative considered: inject a handwritten endpoint into `extendedApi`. This would avoid unrelated generated diff but would duplicate a documented endpoint and undermine issue #78's generated-contract requirement.
 
-### Use a page, query container, and presentational catalog view
+### Use a page, query container, and presentational catalog table
 
-Add a Test Scenarios page under `src/pages/`, with feature code under `src/components/test-scenarios/`. The page supplies the standard template. A container obtains the selected project, owns page state, calls the generated query, and translates query state into explicit view props. A presentational view renders summaries and status states without access to Redux or RTK Query.
+Add a Test Scenarios page under `src/pages/`, with feature code under `src/components/test-scenarios/`. The page supplies the standard template. A container obtains the selected project, owns page state, calls the generated query, and translates query state into explicit view props. A presentational view renders scenario summaries as table rows beneath **Title**, **Created**, and **Updated** headers, places pagination controls below the table, and renders status states outside the table without access to Redux or RTK Query.
 
 Alternative considered: keep query logic and all state branches directly in the page. That is smaller in file count but makes project-switch and stale-data behavior harder to test and diverges from the repository's feature container/view patterns.
 
 ### Reset state through selected-project identity
 
-Key the state-owning catalog container by `selectedProjectId`, with page state initialized to 1 inside that keyed boundary. A project change therefore creates a fresh page state before the new query is issued rather than relying on an effect that runs after an intermediate render. Pass `projectId`, `page`, and an explicit limit of 30 to the generated hook.
+Key the state-owning catalog container by `selectedProjectId`, with page state initialized to 1 inside that keyed boundary. A project change therefore creates a fresh page state before the new query is issued rather than relying on an effect that runs after an intermediate render. Pass `projectId`, `page`, and an explicit limit of 10 to the generated hook.
 
 Use the query result associated with the current arguments for rendering. During an argument change, the view shows the new request's loading state rather than retaining data from the old project. RTK Query's argument-keyed cache may still satisfy repeat visits, but only data keyed to the current project and page can render.
 
@@ -48,11 +49,11 @@ Alternative considered: reset `page` in an effect that watches `selectedProjectI
 
 Map each API record to view data containing only `id`, `title`, `createdAt`, and `updatedAt`. The presentational view never receives `contentMd`. Dates use the repository's established human-readable formatting style, and scenario IDs provide stable render keys.
 
-Alternative considered: pass generated `TestScenario` objects directly to scenario cards. That is less code but allows catalog components to start depending on `contentMd` and couples presentation to the current oversized response.
+Alternative considered: pass generated `TestScenario` objects directly to the table. That is less code but allows catalog components to start depending on `contentMd` and couples presentation to the full response shape.
 
 ### Keep the list non-interactive beyond pagination
 
-Scenario rows/cards will not navigate or expose an affordance that implies detail support. The sidebar entry itself remains a normal link, matching existing navigation behavior. Detail navigation can be introduced with the separate CRUD/detail capability without changing the foundation route.
+Scenario table rows will not navigate or expose an affordance that implies detail support. The sidebar entry itself remains a normal link, matching existing navigation behavior. Detail navigation can be introduced with the separate CRUD/detail capability without changing the foundation route.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/add-project-scoped-test-scenario-list/proposal.md
+++ b/openspec/changes/add-project-scoped-test-scenario-list/proposal.md
@@ -6,7 +6,7 @@ Test Portal users currently have no client entry point for discovering the Markd
 
 - Regenerate the authenticated RTK Query API from the currently available backend OpenAPI contract so Test Scenario types and hooks are available to the client.
 - Add a protected, project-guarded `/test-scenarios` route and a standard **Test Scenarios** sidebar link.
-- Add a paginated catalog that requests scenarios for the selected project and displays each scenario's title and created/updated timestamps.
+- Add a paginated table that requests up to 10 scenarios for the selected project, displays **Title**, **Created**, and **Updated** columns, and places pagination controls below the table.
 - Add loading, error, empty, populated, and pagination states consistent with existing client patterns.
 - Reset pagination and prevent previously selected-project data from remaining visible when the selected project changes.
 - Treat list entries as summaries: do not render or otherwise depend on `contentMd`, even though the current backend list schema includes it.
@@ -26,5 +26,5 @@ None.
 
 - Generated API: `src/redux/apis/generatedApi.ts` will be regenerated from `http://127.0.0.1:3001/api/openapi.json` during implementation.
 - Routing and navigation: `src/types/paths.ts`, `src/router/index.tsx`, and the main navigation configuration.
-- UI: a new Test Scenarios page and catalog/list components using the selected-project state, shared page template, status primitives, and pagination component.
+- UI: a new Test Scenarios page and catalog table components using the selected-project state, shared page template, status primitives, and pagination component.
 - Tests: generated-contract, route/guard, navigation, catalog states, pagination, and project-switch isolation coverage under `src/__tests__/`.

--- a/openspec/changes/add-project-scoped-test-scenario-list/proposal.md
+++ b/openspec/changes/add-project-scoped-test-scenario-list/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Test Portal users currently have no client entry point for discovering the Markdown Test Scenarios that belong to their selected project. The backend already exposes an authenticated, project-scoped paginated list, so the client can establish the Test Management foundation needed before scenario detail and authoring workflows are added.
+
+## What Changes
+
+- Regenerate the authenticated RTK Query API from the currently available backend OpenAPI contract so Test Scenario types and hooks are available to the client.
+- Add a protected, project-guarded `/test-scenarios` route and a standard **Test Scenarios** sidebar link.
+- Add a paginated catalog that requests scenarios for the selected project and displays each scenario's title and created/updated timestamps.
+- Add loading, error, empty, populated, and pagination states consistent with existing client patterns.
+- Reset pagination and prevent previously selected-project data from remaining visible when the selected project changes.
+- Treat list entries as summaries: do not render or otherwise depend on `contentMd`, even though the current backend list schema includes it.
+- Keep scenario detail, creation, editing, deletion, Markdown rendering, Spec links, Results, observed Issues, and MCP browser integration outside this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `test-scenario-catalog`: Authenticated navigation and project-scoped discovery of paginated Test Scenario summaries.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Generated API: `src/redux/apis/generatedApi.ts` will be regenerated from `http://127.0.0.1:3001/api/openapi.json` during implementation.
+- Routing and navigation: `src/types/paths.ts`, `src/router/index.tsx`, and the main navigation configuration.
+- UI: a new Test Scenarios page and catalog/list components using the selected-project state, shared page template, status primitives, and pagination component.
+- Tests: generated-contract, route/guard, navigation, catalog states, pagination, and project-switch isolation coverage under `src/__tests__/`.

--- a/openspec/changes/add-project-scoped-test-scenario-list/specs/test-scenario-catalog/spec.md
+++ b/openspec/changes/add-project-scoped-test-scenario-list/specs/test-scenario-catalog/spec.md
@@ -28,15 +28,17 @@ The system SHALL provide a **Test Scenarios** navigation entry that opens the `/
 
 The system SHALL request only the paginated Test Scenarios belonging to the currently selected project.
 
+The catalog SHALL request a page limit of 10 scenarios.
+
 #### Scenario: Catalog requests its first page
 
 - **WHEN** the catalog loads for a selected project
-- **THEN** the system SHALL request page 1 with the configured page limit and the selected project's `projectId`
+- **THEN** the system SHALL request page 1 with a limit of 10 and the selected project's `projectId`
 
 #### Scenario: User selects another page
 
 - **WHEN** the user selects an available catalog page
-- **THEN** the system SHALL request that page for the same selected project and configured page limit
+- **THEN** the system SHALL request that page for the same selected project with a limit of 10
 
 #### Scenario: Backend returns pagination metadata
 
@@ -45,12 +47,13 @@ The system SHALL request only the paginated Test Scenarios belonging to the curr
 
 ### Requirement: Test Scenario summary presentation
 
-The catalog SHALL present each returned scenario as summary information without rendering or depending on its Markdown content.
+The catalog SHALL present returned scenarios in a table with **Title**, **Created**, and **Updated** columns without rendering or depending on Markdown content.
 
 #### Scenario: Catalog contains scenarios
 
 - **WHEN** the selected project's list response contains one or more scenarios
-- **THEN** the catalog SHALL display each scenario's title and created and updated timestamps
+- **THEN** the catalog SHALL display one table row per scenario
+- **AND** each row SHALL display the scenario title under **Title**, its creation timestamp under **Created**, and its update timestamp under **Updated**
 - **AND** the catalog SHALL NOT display `contentMd`
 
 #### Scenario: List response includes Markdown content
@@ -89,6 +92,7 @@ The catalog SHALL clearly represent loading, error, empty, and populated request
 
 - **WHEN** the scenario-list response reports more than one page
 - **THEN** the catalog SHALL display pagination controls using the reported current and total page values
+- **AND** the pagination controls SHALL appear below the scenario table
 
 ### Requirement: Project-switch isolation
 

--- a/openspec/changes/add-project-scoped-test-scenario-list/specs/test-scenario-catalog/spec.md
+++ b/openspec/changes/add-project-scoped-test-scenario-list/specs/test-scenario-catalog/spec.md
@@ -1,0 +1,112 @@
+## Purpose
+
+Provide authenticated users with a project-isolated catalog for discovering Test Scenario summaries without loading or displaying full Markdown scenario content.
+
+## ADDED Requirements
+
+### Requirement: Authenticated Test Scenario catalog entry point
+
+The system SHALL provide a **Test Scenarios** navigation entry that opens the `/test-scenarios` catalog through the existing authentication and selected-project protections.
+
+#### Scenario: Authenticated user opens the catalog from navigation
+
+- **WHEN** an authenticated user with a selected project activates the **Test Scenarios** navigation item
+- **THEN** the system SHALL navigate to `/test-scenarios`
+- **AND** the system SHALL display the Test Scenario catalog for the selected project
+
+#### Scenario: Unauthenticated user opens the catalog route
+
+- **WHEN** an unauthenticated user attempts to open `/test-scenarios`
+- **THEN** the system SHALL apply the existing protected-route authentication behavior
+
+#### Scenario: User opens the catalog without an available project
+
+- **WHEN** an authenticated user without an available selected project attempts to open `/test-scenarios`
+- **THEN** the system SHALL apply the existing project-guard behavior
+
+### Requirement: Project-scoped Test Scenario retrieval
+
+The system SHALL request only the paginated Test Scenarios belonging to the currently selected project.
+
+#### Scenario: Catalog requests its first page
+
+- **WHEN** the catalog loads for a selected project
+- **THEN** the system SHALL request page 1 with the configured page limit and the selected project's `projectId`
+
+#### Scenario: User selects another page
+
+- **WHEN** the user selects an available catalog page
+- **THEN** the system SHALL request that page for the same selected project and configured page limit
+
+#### Scenario: Backend returns pagination metadata
+
+- **WHEN** a catalog request succeeds
+- **THEN** the system SHALL derive available pagination controls from the response `page`, `limit`, `total`, and `totalPages` metadata
+
+### Requirement: Test Scenario summary presentation
+
+The catalog SHALL present each returned scenario as summary information without rendering or depending on its Markdown content.
+
+#### Scenario: Catalog contains scenarios
+
+- **WHEN** the selected project's list response contains one or more scenarios
+- **THEN** the catalog SHALL display each scenario's title and created and updated timestamps
+- **AND** the catalog SHALL NOT display `contentMd`
+
+#### Scenario: List response includes Markdown content
+
+- **WHEN** the backend list response includes `contentMd` on scenario records
+- **THEN** the catalog SHALL ignore that field
+- **AND** catalog rendering SHALL remain based only on summary fields
+
+#### Scenario: Scenario summary is displayed
+
+- **WHEN** a scenario is shown in this catalog
+- **THEN** the catalog SHALL NOT offer detail, creation, editing, deletion, Markdown preview, relationship, or evidence actions
+
+### Requirement: Catalog request states
+
+The catalog SHALL clearly represent loading, error, empty, and populated request states without crashing the page.
+
+#### Scenario: Initial request is loading
+
+- **WHEN** the selected project's initial scenario-list request is pending
+- **THEN** the catalog SHALL display a loading state consistent with existing client patterns
+
+#### Scenario: Request fails
+
+- **WHEN** the scenario-list request fails for a non-authentication reason
+- **THEN** the catalog SHALL display a useful error state
+- **AND** the catalog SHALL NOT display scenario records from another request scope
+
+#### Scenario: Selected project has no scenarios
+
+- **WHEN** the scenario-list request succeeds with an empty `scenarios` array
+- **THEN** the catalog SHALL display a clear no-scenarios state
+- **AND** the catalog SHALL NOT display pagination controls
+
+#### Scenario: Selected project has multiple pages
+
+- **WHEN** the scenario-list response reports more than one page
+- **THEN** the catalog SHALL display pagination controls using the reported current and total page values
+
+### Requirement: Project-switch isolation
+
+The catalog SHALL reset its pagination and visible scenario state when the selected project changes.
+
+#### Scenario: User switches projects from a later page
+
+- **WHEN** the catalog is displaying a page later than page 1 and the user selects another project
+- **THEN** the catalog SHALL reset to page 1 for the newly selected project
+- **AND** the first request for the newly selected project SHALL use page 1
+
+#### Scenario: New project request is pending
+
+- **WHEN** the selected project changes and its scenario-list request has not completed
+- **THEN** the catalog SHALL NOT display scenarios returned for the previously selected project
+
+#### Scenario: User returns to a previously viewed project
+
+- **WHEN** the user returns to a project that has cached scenario-list data
+- **THEN** the catalog SHALL still begin at page 1
+- **AND** any displayed cached data SHALL belong to that selected project and page

--- a/openspec/changes/add-project-scoped-test-scenario-list/tasks.md
+++ b/openspec/changes/add-project-scoped-test-scenario-list/tasks.md
@@ -1,22 +1,22 @@
 ## 1. Generated API Contract
 
-- [ ] 1.1 Regenerate `src/redux/apis/generatedApi.ts` with `RTK_QUERY_OPENAPI_URL=http://127.0.0.1:3001/api/openapi.json yarn generate-api`, verify the generated Test Scenario list hook accepts `projectId`, `page`, and `limit`, and review the generated diff for unrelated backend contract drift.
-- [ ] 1.2 Add compile-time generated-contract coverage for the Test Scenario list arguments, scenario fields, and pagination metadata, and verify the focused contract test and `yarn tsc` pass without hand-edited generated declarations.
+- [x] 1.1 Regenerate `src/redux/apis/generatedApi.ts` with `RTK_QUERY_OPENAPI_URL=http://127.0.0.1:3001/api/openapi.json yarn generate-api`, verify the generated Test Scenario list hook accepts `projectId`, `page`, and `limit`, and review the generated diff for unrelated backend contract drift.
+- [x] 1.2 Add compile-time generated-contract coverage for the Test Scenario list arguments, scenario fields, and pagination metadata, and verify the focused contract test and `yarn tsc` pass without hand-edited generated declarations.
 
 ## 2. Test Scenario Catalog Components
 
-- [ ] 2.1 Add summary view types and an API-to-view mapping that exposes only scenario ID, title, created timestamp, and updated timestamp, and verify unit coverage demonstrates that `contentMd` is not passed to presentation.
-- [ ] 2.2 Add a presentational catalog view for loading, error, empty, populated, and paginated states using existing Chakra UI and shared pagination patterns, and verify focused component tests cover every state and page selection.
-- [ ] 2.3 Add a query container that requests page 1 with limit 30 for the selected project, uses only current-argument response data, and verifies through focused tests that page changes send the correct `projectId`, `page`, and `limit`.
-- [ ] 2.4 Add the selected-project keyed boundary around the state-owning container, and verify a rerender with another project resets the first request to page 1 and never presents records from the previous project.
+- [x] 2.1 Add summary view types and an API-to-view mapping that exposes only scenario ID, title, created timestamp, and updated timestamp, and verify unit coverage demonstrates that `contentMd` is not passed to presentation.
+- [x] 2.2 Add a presentational catalog table with **Title**, **Created**, and **Updated** columns plus loading, error, empty, and paginated states using existing Chakra UI and shared pagination patterns, and verify focused component tests cover the headers, rows, every state, and page selection.
+- [x] 2.3 Add a query container that requests page 1 with limit 10 for the selected project, uses only current-argument response data, and verifies through focused tests that page changes send the correct `projectId`, `page`, and `limit`.
+- [x] 2.4 Add the selected-project keyed boundary around the state-owning container, and verify a rerender with another project resets the first request to page 1 and never presents records from the previous project.
 
 ## 3. Route and Navigation Integration
 
-- [ ] 3.1 Add the `/test-scenarios` path constant, Test Scenarios page with `MainTemplate`, and required page/component exports, and verify the page renders the catalog under the expected heading.
-- [ ] 3.2 Register `/test-scenarios` with `ProtectedRoute` and `ProjectGuard`, and verify route tests cover authenticated access plus the existing unauthenticated and no-project guard behavior.
-- [ ] 3.3 Add **Test Scenarios** to the main navigation as a standard link and update navigation tests to verify its label, destination, and active-route behavior.
+- [x] 3.1 Add the `/test-scenarios` path constant, Test Scenarios page with `MainTemplate`, and required page/component exports, and verify the page renders the catalog under the expected heading.
+- [x] 3.2 Register `/test-scenarios` with `ProtectedRoute` and `ProjectGuard`, and verify route tests cover authenticated access plus the existing unauthenticated and no-project guard behavior.
+- [x] 3.3 Add **Test Scenarios** to the main navigation as a standard link and update navigation tests to verify its label, destination, and active-route behavior.
 
 ## 4. Validation
 
-- [ ] 4.1 Run all focused generated-contract, catalog, project-switch, route, and navigation tests and verify they pass together.
-- [ ] 4.2 Run `yarn lint`, `yarn test`, and `yarn build`, then verify `git diff --check` and `openspec validate add-project-scoped-test-scenario-list --strict` pass with unrelated worktree changes left untouched.
+- [x] 4.1 Run all focused generated-contract, catalog, project-switch, route, and navigation tests and verify they pass together.
+- [x] 4.2 Run `yarn lint`, `yarn test`, and `yarn build`, then verify `git diff --check` and `openspec validate add-project-scoped-test-scenario-list --strict` pass with unrelated worktree changes left untouched.

--- a/openspec/changes/add-project-scoped-test-scenario-list/tasks.md
+++ b/openspec/changes/add-project-scoped-test-scenario-list/tasks.md
@@ -1,0 +1,22 @@
+## 1. Generated API Contract
+
+- [ ] 1.1 Regenerate `src/redux/apis/generatedApi.ts` with `RTK_QUERY_OPENAPI_URL=http://127.0.0.1:3001/api/openapi.json yarn generate-api`, verify the generated Test Scenario list hook accepts `projectId`, `page`, and `limit`, and review the generated diff for unrelated backend contract drift.
+- [ ] 1.2 Add compile-time generated-contract coverage for the Test Scenario list arguments, scenario fields, and pagination metadata, and verify the focused contract test and `yarn tsc` pass without hand-edited generated declarations.
+
+## 2. Test Scenario Catalog Components
+
+- [ ] 2.1 Add summary view types and an API-to-view mapping that exposes only scenario ID, title, created timestamp, and updated timestamp, and verify unit coverage demonstrates that `contentMd` is not passed to presentation.
+- [ ] 2.2 Add a presentational catalog view for loading, error, empty, populated, and paginated states using existing Chakra UI and shared pagination patterns, and verify focused component tests cover every state and page selection.
+- [ ] 2.3 Add a query container that requests page 1 with limit 30 for the selected project, uses only current-argument response data, and verifies through focused tests that page changes send the correct `projectId`, `page`, and `limit`.
+- [ ] 2.4 Add the selected-project keyed boundary around the state-owning container, and verify a rerender with another project resets the first request to page 1 and never presents records from the previous project.
+
+## 3. Route and Navigation Integration
+
+- [ ] 3.1 Add the `/test-scenarios` path constant, Test Scenarios page with `MainTemplate`, and required page/component exports, and verify the page renders the catalog under the expected heading.
+- [ ] 3.2 Register `/test-scenarios` with `ProtectedRoute` and `ProjectGuard`, and verify route tests cover authenticated access plus the existing unauthenticated and no-project guard behavior.
+- [ ] 3.3 Add **Test Scenarios** to the main navigation as a standard link and update navigation tests to verify its label, destination, and active-route behavior.
+
+## 4. Validation
+
+- [ ] 4.1 Run all focused generated-contract, catalog, project-switch, route, and navigation tests and verify they pass together.
+- [ ] 4.2 Run `yarn lint`, `yarn test`, and `yarn build`, then verify `git diff --check` and `openspec validate add-project-scoped-test-scenario-list --strict` pass with unrelated worktree changes left untouched.

--- a/src/__tests__/components/ProjectGuard.test.tsx
+++ b/src/__tests__/components/ProjectGuard.test.tsx
@@ -1,0 +1,70 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ProjectGuard } from '@/components/ProjectGuard';
+import { PATHS } from '@/types/paths';
+import { useGetApiV2ProjectsQuery } from '@/redux/apis/generatedApi';
+import { useIsInitialized, useProjectsActions, useSelectedProjectId } from '@/redux/slices/projects';
+
+vi.mock('@/components/ui/LoadingPlaceholder', () => ({
+  LoadingPlaceholder: () => <div>Loading projects</div>,
+}));
+vi.mock('@/redux/apis/generatedApi', () => ({
+  useGetApiV2ProjectsQuery: vi.fn(),
+}));
+vi.mock('@/redux/slices/projects', () => ({
+  useIsInitialized: vi.fn(),
+  useProjectsActions: vi.fn(),
+  useSelectedProjectId: vi.fn(),
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
+
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+const mockedProjectsQuery = vi.mocked(useGetApiV2ProjectsQuery);
+const mockedIsInitialized = vi.mocked(useIsInitialized);
+const mockedSelectedProjectId = vi.mocked(useSelectedProjectId);
+const mockedProjectsActions = vi.mocked(useProjectsActions);
+
+afterEach(() => {
+  navigate.mockReset();
+  mockedProjectsQuery.mockReset();
+  mockedIsInitialized.mockReset();
+  mockedSelectedProjectId.mockReset();
+  mockedProjectsActions.mockReset();
+});
+
+describe('ProjectGuard', () => {
+  it('redirects authenticated routes to project settings when no project is available', async () => {
+    const setIsInitialized = vi.fn();
+
+    mockedProjectsQuery.mockReturnValue({ data: [], isLoading: false } as never);
+    mockedIsInitialized.mockReturnValue(false);
+    mockedSelectedProjectId.mockReturnValue('');
+    mockedProjectsActions.mockReturnValue({ setIsInitialized, setSelectedProjectId: vi.fn() } as never);
+
+    render(
+      <MemoryRouter>
+        <ProjectGuard>
+          <div>Test Scenario catalog</div>
+        </ProjectGuard>
+      </MemoryRouter>,
+    );
+
+    await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith(PATHS.USER_SETTINGS_PROJECTS));
+    expect(setIsInitialized).toHaveBeenCalledWith(true);
+    expect(screen.queryByText('Test Scenario catalog')).not.toBeInTheDocument();
+  });
+});
+

--- a/src/__tests__/components/ProtectedRoute.test.tsx
+++ b/src/__tests__/components/ProtectedRoute.test.tsx
@@ -1,0 +1,51 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router';
+import { useSelector } from 'react-redux';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ProtectedRoute } from '@/components/ProtectedRoute';
+
+vi.mock('react-redux', () => ({
+  useSelector: vi.fn(),
+}));
+
+const mockedUseSelector = vi.mocked(useSelector);
+
+const LocationProbe = () => <output data-testid="location">{useLocation().pathname}</output>;
+
+const renderProtectedRoute = () =>
+  render(
+    <MemoryRouter initialEntries={['/test-scenarios']}>
+      <ProtectedRoute>
+        <div>Test Scenario catalog</div>
+      </ProtectedRoute>
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+
+afterEach(() => {
+  mockedUseSelector.mockReset();
+});
+
+describe('ProtectedRoute', () => {
+  it('renders the catalog for an authenticated user with an access token', () => {
+    mockedUseSelector.mockReturnValue({ isAuthenticated: true, accessToken: 'access-token' } as never);
+
+    renderProtectedRoute();
+
+    expect(screen.getByText('Test Scenario catalog')).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('/test-scenarios');
+  });
+
+  it('redirects an unauthenticated user to login', () => {
+    mockedUseSelector.mockReturnValue({ isAuthenticated: false, accessToken: null } as never);
+
+    renderProtectedRoute();
+
+    expect(screen.queryByText('Test Scenario catalog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('/login');
+  });
+});

--- a/src/__tests__/components/test-scenarios/TestScenarioCatalogBoundary.test.tsx
+++ b/src/__tests__/components/test-scenarios/TestScenarioCatalogBoundary.test.tsx
@@ -1,0 +1,96 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChakraProvider } from '@/components/ui';
+import { TestScenarioCatalog } from '@/components/test-scenarios/containers/TestScenarioCatalogBoundary';
+import { useSelectedProject } from '@/hooks/useSelectedProject';
+import {
+  useGetApiV2TestScenariosQuery,
+  type GetApiV2TestScenariosApiArg,
+} from '@/redux/apis/generatedApi';
+
+vi.mock('@/hooks/useSelectedProject', () => ({
+  useSelectedProject: vi.fn(),
+}));
+vi.mock('@/redux/apis/generatedApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/redux/apis/generatedApi')>();
+
+  return {
+    ...actual,
+    useGetApiV2TestScenariosQuery: vi.fn(),
+  };
+});
+
+const mockedSelectedProject = vi.mocked(useSelectedProject);
+const mockedScenarioQuery = vi.mocked(useGetApiV2TestScenariosQuery);
+let selectedProjectId = 'project-a';
+
+const createResponse = (projectId: string, page: number) => ({
+  scenarios: [
+    {
+      id: `${projectId}-scenario`,
+      projectId,
+      createdById: 'user-1',
+      title: `${projectId} scenario`,
+      contentMd: `# ${projectId} scenario`,
+      createdAt: '2026-09-01T10:00:00.000Z',
+      updatedAt: '2026-09-02T11:00:00.000Z',
+    },
+  ],
+  total: 11,
+  page,
+  limit: 10,
+  totalPages: 2,
+});
+
+describe('TestScenarioCatalog project boundary', () => {
+  beforeEach(() => {
+    selectedProjectId = 'project-a';
+    mockedSelectedProject.mockImplementation(() => ({
+      selectedProjectId,
+      project: undefined,
+      isLoading: false,
+    }));
+    mockedScenarioQuery.mockImplementation((args) => {
+      const queryArgs = args as GetApiV2TestScenariosApiArg;
+
+      if (queryArgs.projectId === 'project-b') {
+        return { currentData: undefined, isLoading: true, isFetching: true, error: undefined } as never;
+      }
+
+      return {
+        currentData: createResponse(queryArgs.projectId, queryArgs.page ?? 1),
+        isLoading: false,
+        isFetching: false,
+        error: undefined,
+      } as never;
+    });
+  });
+
+  it('resets to page 1 and hides the previous project while the new request is pending', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ChakraProvider>
+        <TestScenarioCatalog />
+      </ChakraProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^2$/ }));
+    expect(screen.getByText('project-a scenario')).toBeInTheDocument();
+
+    selectedProjectId = 'project-b';
+    rerender(
+      <ChakraProvider>
+        <TestScenarioCatalog />
+      </ChakraProvider>,
+    );
+
+    expect(mockedScenarioQuery).toHaveBeenLastCalledWith({ projectId: 'project-b', page: 1, limit: 10 });
+    expect(screen.queryByText('project-a scenario')).not.toBeInTheDocument();
+    expect(screen.getByText('Loading Test Scenarios...')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/test-scenarios/TestScenarioCatalogContainer.test.tsx
+++ b/src/__tests__/components/test-scenarios/TestScenarioCatalogContainer.test.tsx
@@ -1,0 +1,81 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChakraProvider } from '@/components/ui';
+import { TestScenarioCatalogContainer } from '@/components/test-scenarios/containers/TestScenarioCatalogContainer';
+import { useGetApiV2TestScenariosQuery, type GetApiV2TestScenariosApiArg } from '@/redux/apis/generatedApi';
+
+vi.mock('@/redux/apis/generatedApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/redux/apis/generatedApi')>();
+
+  return {
+    ...actual,
+    useGetApiV2TestScenariosQuery: vi.fn(),
+  };
+});
+
+const mockedScenarioQuery = vi.mocked(useGetApiV2TestScenariosQuery);
+
+const createResponse = (page: number) => ({
+  scenarios: [
+    {
+      id: `scenario-${page}`,
+      projectId: 'project-1',
+      createdById: 'user-1',
+      title: `Scenario page ${page}`,
+      contentMd: `# Scenario page ${page}`,
+      createdAt: '2026-09-01T10:00:00.000Z',
+      updatedAt: '2026-09-02T11:00:00.000Z',
+    },
+  ],
+  total: 11,
+  page,
+  limit: 10,
+  totalPages: 2,
+});
+
+describe('TestScenarioCatalogContainer', () => {
+  beforeEach(() => {
+    mockedScenarioQuery.mockImplementation((args) => {
+      const queryArgs = args as GetApiV2TestScenariosApiArg;
+
+      return {
+      currentData: createResponse(queryArgs.page ?? 1),
+      isLoading: false,
+      isFetching: false,
+      error: undefined,
+      } as never;
+    });
+  });
+
+  it('requests the selected project first with page 1 and limit 10', () => {
+    render(
+      <ChakraProvider>
+        <TestScenarioCatalogContainer projectId="project-1" />
+      </ChakraProvider>,
+    );
+
+    expect(mockedScenarioQuery).toHaveBeenCalledWith({ projectId: 'project-1', page: 1, limit: 10 });
+    expect(screen.getByText('Scenario page 1')).toBeInTheDocument();
+  });
+
+  it('requests the selected page for the same project and limit', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ChakraProvider>
+        <TestScenarioCatalogContainer projectId="project-1" />
+      </ChakraProvider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^2$/ }));
+
+    expect(mockedScenarioQuery).toHaveBeenLastCalledWith({ projectId: 'project-1', page: 2, limit: 10 });
+    expect(screen.getByText('Scenario page 2')).toBeInTheDocument();
+    expect(screen.queryByText('# Scenario page 2')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/test-scenarios/TestScenarioCatalogView.test.tsx
+++ b/src/__tests__/components/test-scenarios/TestScenarioCatalogView.test.tsx
@@ -1,0 +1,98 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChakraProvider } from '@/components/ui';
+import { TestScenarioCatalogView, type TestScenarioCatalogViewProps } from '@/components/test-scenarios/components/TestScenarioCatalogView';
+
+const scenarios = [
+  {
+    id: 'scenario-1',
+    title: 'Checkout flow',
+    createdAt: '2026-09-01T10:00:00.000Z',
+    updatedAt: '2026-09-02T11:00:00.000Z',
+  },
+];
+
+const pagination = {
+  page: 1,
+  limit: 10,
+  total: 1,
+  totalPages: 1,
+};
+
+const renderView = (props: Partial<TestScenarioCatalogViewProps> = {}) =>
+  render(
+    <ChakraProvider>
+      <TestScenarioCatalogView
+        scenarios={scenarios}
+        pagination={pagination}
+        isLoading={false}
+        onPageChange={vi.fn()}
+        {...props}
+      />
+    </ChakraProvider>,
+  );
+
+describe('TestScenarioCatalogView', () => {
+  it('renders the loading state', () => {
+    renderView({ scenarios: [], isLoading: true });
+
+    expect(screen.getByLabelText('Loading Test Scenarios')).toBeInTheDocument();
+    expect(screen.getByText('Loading Test Scenarios...')).toBeInTheDocument();
+  });
+
+  it('renders the error state without scenario records', () => {
+    renderView({ error: { status: 500 } });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load Test Scenarios');
+    expect(screen.queryByText('Checkout flow')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state without pagination controls', () => {
+    renderView({ scenarios: [], pagination: { ...pagination, total: 0, totalPages: 0 } });
+
+    expect(screen.getByText('No Test Scenarios are available for this project.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Next Page' })).not.toBeInTheDocument();
+  });
+
+  it('renders scenario summaries as table rows without Markdown content or detail actions', () => {
+    renderView();
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getAllByRole('columnheader')).toHaveLength(3);
+    expect(screen.getByRole('columnheader', { name: 'Title' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Created' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Updated' })).toBeInTheDocument();
+    expect(screen.getAllByRole('row')).toHaveLength(2);
+    expect(screen.getByRole('row', { name: /Checkout flow/ })).toBeInTheDocument();
+    expect(screen.queryByText('# Checkout flow')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders pagination from the response metadata and reports page selection', async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+
+    renderView({
+      pagination: { page: 1, limit: 10, total: 11, totalPages: 2 },
+      onPageChange,
+    });
+
+    const table = screen.getByRole('table');
+    const pagination = screen.getByRole('navigation', { name: 'Test Scenario pagination' });
+    const summary = screen.getByText('Showing 1-10 of 11 Test Scenarios');
+
+    expect(table.compareDocumentPosition(pagination) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(pagination.compareDocumentPosition(summary) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: /^2$/ }));
+
+    expect(onPageChange).toHaveBeenCalledWith(2);
+    expect(summary).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/test-scenarios/testScenarioSummary.test.ts
+++ b/src/__tests__/components/test-scenarios/testScenarioSummary.test.ts
@@ -1,0 +1,42 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import type { TestScenario } from '@/redux/apis/generatedApi';
+import { mapTestScenarioToSummary, mapTestScenariosToSummaries } from '@/components/test-scenarios/utils';
+
+const scenario: TestScenario = {
+  id: 'scenario-1',
+  projectId: 'project-1',
+  createdById: 'user-1',
+  title: 'Checkout flow',
+  contentMd: '# Checkout flow\n\nSensitive Markdown content',
+  createdAt: '2026-09-01T10:00:00.000Z',
+  updatedAt: '2026-09-02T11:00:00.000Z',
+};
+
+describe('Test Scenario summary mapping', () => {
+  it('projects only the fields used by the catalog', () => {
+    const summary = mapTestScenarioToSummary(scenario);
+
+    expect(summary).toEqual({
+      id: 'scenario-1',
+      title: 'Checkout flow',
+      createdAt: '2026-09-01T10:00:00.000Z',
+      updatedAt: '2026-09-02T11:00:00.000Z',
+    });
+    expect(Object.hasOwn(summary, 'contentMd')).toBe(false);
+  });
+
+  it('maps every API record to a summary without passing Markdown content through', () => {
+    expect(mapTestScenariosToSummaries([scenario])).toEqual([
+      {
+        id: 'scenario-1',
+        title: 'Checkout flow',
+        createdAt: '2026-09-01T10:00:00.000Z',
+        updatedAt: '2026-09-02T11:00:00.000Z',
+      },
+    ]);
+  });
+});

--- a/src/__tests__/components/ui/NavigationMenu/NavigationMenu.test.tsx
+++ b/src/__tests__/components/ui/NavigationMenu/NavigationMenu.test.tsx
@@ -13,6 +13,7 @@ describe('NavigationMenu', () => {
     ['Dashboard', '/dashboard'],
     ['Results', '/results'],
     ['Issues', '/issues'],
+    ['Test Scenarios', '/test-scenarios'],
     ['Prompts', '/prompts'],
     ['Skills', '/skills'],
     ['Settings', '/settings'],
@@ -26,5 +27,17 @@ describe('NavigationMenu', () => {
     );
 
     expect(screen.getByRole('link', { name: label })).toHaveAttribute('href', path);
+  });
+
+  it('marks Test Scenarios active on its route', () => {
+    render(
+      <ChakraProvider>
+        <MemoryRouter initialEntries={['/test-scenarios']}>
+          <NavigationMenu collapsed={false} />
+        </MemoryRouter>
+      </ChakraProvider>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Test Scenarios' })).toHaveAttribute('aria-current', 'page');
   });
 });

--- a/src/__tests__/pages/TestScenarios/TestScenariosPage.test.tsx
+++ b/src/__tests__/pages/TestScenarios/TestScenariosPage.test.tsx
@@ -1,0 +1,29 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TestScenariosPage } from '@/pages/TestScenarios';
+
+vi.mock('@/components/ui/components/Templates/MainTemplate', () => ({
+  MainTemplate: ({ children, pageHeader }: { children: React.ReactNode; pageHeader: string }) => (
+    <main>
+      <h1>{pageHeader}</h1>
+      {children}
+    </main>
+  ),
+}));
+
+vi.mock('@/components/test-scenarios', () => ({
+  TestScenarioCatalog: () => <div>Test Scenario catalog</div>,
+}));
+
+describe('TestScenariosPage', () => {
+  it('renders the catalog under the Test Scenarios heading', () => {
+    render(<TestScenariosPage />);
+
+    expect(screen.getByRole('heading', { name: 'Test Scenarios' })).toBeInTheDocument();
+    expect(screen.getByText('Test Scenario catalog')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/redux/apis/testScenarioApi.test.ts
+++ b/src/__tests__/redux/apis/testScenarioApi.test.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import {
+  type GetApiV2TestScenariosApiArg,
+  type TestScenario,
+  type TestScenarioListResponse,
+} from '@/redux/apis/generatedApi';
+
+const scenario: TestScenario = {
+  id: 'scenario-1',
+  projectId: 'project-1',
+  createdById: 'user-1',
+  title: 'Checkout flow',
+  contentMd: '# Checkout flow',
+  createdAt: '2026-09-01T10:00:00.000Z',
+  updatedAt: '2026-09-02T11:00:00.000Z',
+};
+
+const listArgs: GetApiV2TestScenariosApiArg = {
+  projectId: 'project-1',
+  page: 2,
+  limit: 30,
+};
+
+const listResponse: TestScenarioListResponse = {
+  scenarios: [scenario],
+  total: 31,
+  page: 2,
+  limit: 30,
+  totalPages: 2,
+};
+
+describe('generated Test Scenario list contract', () => {
+  it('exposes scenario fields and pagination metadata at compile time', () => {
+    expectTypeOf(listArgs).toEqualTypeOf<GetApiV2TestScenariosApiArg>();
+    expectTypeOf(listResponse).toEqualTypeOf<TestScenarioListResponse>();
+    expect(scenario).toMatchObject({
+      id: expect.any(String),
+      projectId: expect.any(String),
+      createdById: expect.any(String),
+      title: expect.any(String),
+      contentMd: expect.any(String),
+      createdAt: expect.any(String),
+      updatedAt: expect.any(String),
+    });
+    expect(listResponse).toMatchObject({
+      scenarios: [scenario],
+      total: 31,
+      page: 2,
+      limit: 30,
+      totalPages: 2,
+    });
+    expect(listArgs).toEqual({ projectId: 'project-1', page: 2, limit: 30 });
+  });
+});

--- a/src/__tests__/router/index.test.tsx
+++ b/src/__tests__/router/index.test.tsx
@@ -1,0 +1,29 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { isValidElement, type ReactElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { ProjectGuard, ProtectedRoute } from '@/components';
+import { TestScenariosPage } from '@/pages';
+import { router } from '@/router';
+import { PATHS } from '@/types/paths';
+
+describe('Test Scenarios route', () => {
+  it('registers the catalog page behind authentication and project guards', () => {
+    const route = router.routes.find((candidate) => candidate.path === PATHS.TEST_SCENARIOS) as
+      | { element?: ReactElement; path?: string }
+      | undefined;
+
+    expect(route).toBeDefined();
+    expect(isValidElement(route?.element)).toBe(true);
+
+    const protectedElement = route?.element as ReactElement<{ children: ReactElement }>;
+    expect(protectedElement.type).toBe(ProtectedRoute);
+    expect(isValidElement(protectedElement.props.children)).toBe(true);
+
+    const projectGuardElement = protectedElement.props.children as ReactElement<{ children: ReactElement }>;
+    expect(projectGuardElement.type).toBe(ProjectGuard);
+    expect(projectGuardElement.props.children.type).toBe(TestScenariosPage);
+  });
+});

--- a/src/components/test-scenarios/components/TestScenarioCatalogView.tsx
+++ b/src/components/test-scenarios/components/TestScenarioCatalogView.tsx
@@ -1,0 +1,158 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { memo } from 'react';
+import { Box, Heading, HStack, Table, Text, VStack } from '@chakra-ui/react';
+
+import { Alert, Pagination, Skeleton, Wrap } from '@/components/ui';
+
+import type { TestScenarioPagination, TestScenarioSummary } from '../types';
+
+export interface TestScenarioCatalogViewProps {
+  scenarios: TestScenarioSummary[];
+  pagination: TestScenarioPagination;
+  isLoading: boolean;
+  error?: unknown;
+  onPageChange: (page: number) => void;
+}
+
+const formatScenarioDate = (timestamp: string) => new Date(timestamp).toLocaleString('en-US');
+
+const TABLE_CELL_PADDING = { px: 4, py: 3 } as const;
+
+const LoadingState = () => (
+  <VStack align="stretch" gap={4} aria-label="Loading Test Scenarios">
+    <Text color="text.secondary">Loading Test Scenarios...</Text>
+    <Box overflowX="auto">
+      <Table.Root size="sm" variant="outline" minW="600px">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader {...TABLE_CELL_PADDING}>Title</Table.ColumnHeader>
+            <Table.ColumnHeader {...TABLE_CELL_PADDING}>Created</Table.ColumnHeader>
+            <Table.ColumnHeader {...TABLE_CELL_PADDING}>Updated</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {[1, 2, 3].map((index) => (
+            <Table.Row key={index}>
+              <Table.Cell {...TABLE_CELL_PADDING}>
+                <Skeleton h="5" loading={true} />
+              </Table.Cell>
+              <Table.Cell {...TABLE_CELL_PADDING}>
+                <Skeleton h="5" loading={true} />
+              </Table.Cell>
+              <Table.Cell {...TABLE_CELL_PADDING}>
+                <Skeleton h="5" loading={true} />
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  </VStack>
+);
+
+const ErrorState = () => (
+  <Alert.Root status="error" role="alert">
+    <Alert.Indicator />
+    <Alert.Content>
+      <Alert.Title>Failed to load Test Scenarios</Alert.Title>
+      <Alert.Description>Please try again in a moment.</Alert.Description>
+    </Alert.Content>
+  </Alert.Root>
+);
+
+const EmptyState = () => (
+  <VStack py={8}>
+    <Text color="text.muted">No Test Scenarios are available for this project.</Text>
+  </VStack>
+);
+
+const ScenarioTable = ({ scenarios }: { scenarios: TestScenarioSummary[] }) => (
+  <Box overflowX="auto">
+    <Table.Root size="sm" variant="outline" minW="600px">
+      <Table.Header>
+        <Table.Row>
+          <Table.ColumnHeader {...TABLE_CELL_PADDING}>Title</Table.ColumnHeader>
+          <Table.ColumnHeader {...TABLE_CELL_PADDING}>Created</Table.ColumnHeader>
+          <Table.ColumnHeader {...TABLE_CELL_PADDING}>Updated</Table.ColumnHeader>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {scenarios.map((scenario) => (
+          <Table.Row key={scenario.id} data-testid={`test-scenario-${scenario.id}`}>
+            <Table.Cell {...TABLE_CELL_PADDING}>
+              <Text fontWeight="medium" color="text.main">
+                {scenario.title}
+              </Text>
+            </Table.Cell>
+            <Table.Cell {...TABLE_CELL_PADDING} color="text.secondary">
+              {formatScenarioDate(scenario.createdAt)}
+            </Table.Cell>
+            <Table.Cell {...TABLE_CELL_PADDING} color="text.secondary">
+              {formatScenarioDate(scenario.updatedAt)}
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table.Root>
+  </Box>
+);
+
+const PaginationSummary = ({ pagination }: { pagination: TestScenarioPagination }) => {
+  const firstItem = pagination.total === 0 ? 0 : (pagination.page - 1) * pagination.limit + 1;
+  const lastItem = Math.min(pagination.page * pagination.limit, pagination.total);
+
+  return (
+    <HStack justify="flex-end" align="center" gap={4} flexWrap="wrap" w="100%">
+      <Text color="text.secondary" fontSize="sm" textAlign="right">
+        Showing {firstItem}-{lastItem} of {pagination.total} Test Scenarios
+      </Text>
+    </HStack>
+  );
+};
+
+export const TestScenarioCatalogView = memo(function TestScenarioCatalogView({
+  scenarios,
+  pagination,
+  isLoading,
+  error,
+  onPageChange,
+}: TestScenarioCatalogViewProps) {
+  return (
+    <Wrap my={4} mx={6} p={4}>
+      <VStack align="stretch" gap={4} w="100%">
+        <VStack align="start" gap={2}>
+          <Heading fontSize="lg">Test Scenarios</Heading>
+          <Text color="text.secondary">
+            Browse the Markdown Test Scenarios available in the selected project.
+          </Text>
+        </VStack>
+
+        {isLoading ? (
+          <LoadingState />
+        ) : error ? (
+          <ErrorState />
+        ) : scenarios.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <VStack align="stretch" gap={4}>
+            <ScenarioTable scenarios={scenarios} />
+            {pagination.totalPages > 1 && (
+              <Box as="nav" aria-label="Test Scenario pagination">
+                <HStack justify="center" py={2}>
+                  <Pagination
+                    currentPage={pagination.page}
+                    totalPages={pagination.totalPages}
+                    onPageChange={onPageChange}
+                  />
+                </HStack>
+              </Box>
+            )}
+            <PaginationSummary pagination={pagination} />
+          </VStack>
+        )}
+      </VStack>
+    </Wrap>
+  );
+});

--- a/src/components/test-scenarios/components/TestScenarioCatalogView.tsx
+++ b/src/components/test-scenarios/components/TestScenarioCatalogView.tsx
@@ -18,7 +18,7 @@ export interface TestScenarioCatalogViewProps {
 
 const formatScenarioDate = (timestamp: string) => new Date(timestamp).toLocaleString('en-US');
 
-const TABLE_CELL_PADDING = { px: 4, py: 3 } as const;
+const TABLE_CELL_PADDING = { px: 4, py: 4 } as const;
 
 const LoadingState = () => (
   <VStack align="stretch" gap={4} aria-label="Loading Test Scenarios">
@@ -124,9 +124,7 @@ export const TestScenarioCatalogView = memo(function TestScenarioCatalogView({
       <VStack align="stretch" gap={4} w="100%">
         <VStack align="start" gap={2}>
           <Heading fontSize="lg">Test Scenarios</Heading>
-          <Text color="text.secondary">
-            Browse the Markdown Test Scenarios available in the selected project.
-          </Text>
+          <Text color="text.secondary">Browse the Markdown Test Scenarios available in the selected project.</Text>
         </VStack>
 
         {isLoading ? (

--- a/src/components/test-scenarios/components/index.ts
+++ b/src/components/test-scenarios/components/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './TestScenarioCatalogView';
+

--- a/src/components/test-scenarios/constants.ts
+++ b/src/components/test-scenarios/constants.ts
@@ -1,0 +1,4 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+export const TEST_SCENARIO_PAGE_LIMIT = 10;

--- a/src/components/test-scenarios/containers/TestScenarioCatalogBoundary.tsx
+++ b/src/components/test-scenarios/containers/TestScenarioCatalogBoundary.tsx
@@ -1,0 +1,19 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { useSelectedProject } from '@/hooks/useSelectedProject';
+
+import { TestScenarioCatalogContainer } from './TestScenarioCatalogContainer';
+
+export const TestScenarioCatalog = () => {
+  const { selectedProjectId } = useSelectedProject();
+
+  if (!selectedProjectId) {
+    return null;
+  }
+
+  return <TestScenarioCatalogContainer key={selectedProjectId} projectId={selectedProjectId} />;
+};
+
+export const TestScenarioCatalogBoundary = TestScenarioCatalog;
+

--- a/src/components/test-scenarios/containers/TestScenarioCatalogContainer.tsx
+++ b/src/components/test-scenarios/containers/TestScenarioCatalogContainer.tsx
@@ -1,0 +1,16 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { TestScenarioCatalogView } from '../components/TestScenarioCatalogView';
+import { useTestScenarioCatalog } from '../hooks/useTestScenarioCatalog';
+
+export interface TestScenarioCatalogContainerProps {
+  projectId: string;
+}
+
+export const TestScenarioCatalogContainer = ({ projectId }: TestScenarioCatalogContainerProps) => {
+  const catalog = useTestScenarioCatalog(projectId);
+
+  return <TestScenarioCatalogView {...catalog} />;
+};
+

--- a/src/components/test-scenarios/containers/index.ts
+++ b/src/components/test-scenarios/containers/index.ts
@@ -1,0 +1,6 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './TestScenarioCatalogBoundary';
+export * from './TestScenarioCatalogContainer';
+

--- a/src/components/test-scenarios/hooks/index.ts
+++ b/src/components/test-scenarios/hooks/index.ts
@@ -1,0 +1,5 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './useTestScenarioCatalog';
+

--- a/src/components/test-scenarios/hooks/useTestScenarioCatalog.ts
+++ b/src/components/test-scenarios/hooks/useTestScenarioCatalog.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useMemo, useState } from 'react';
+
+import { useGetApiV2TestScenariosQuery } from '@/redux/apis/generatedApi';
+
+import { TEST_SCENARIO_PAGE_LIMIT } from '../constants';
+import { mapTestScenariosToSummaries } from '../utils';
+
+export const useTestScenarioCatalog = (projectId: string) => {
+  const [page, setPage] = useState(1);
+  const queryArgs = useMemo(
+    () => ({ projectId, page, limit: TEST_SCENARIO_PAGE_LIMIT }),
+    [page, projectId],
+  );
+  const { currentData, isLoading: isQueryLoading, isFetching, error } = useGetApiV2TestScenariosQuery(queryArgs);
+
+  const scenarios = useMemo(
+    () => mapTestScenariosToSummaries(currentData?.scenarios ?? []),
+    [currentData?.scenarios],
+  );
+  const pagination = currentData
+    ? {
+        page: currentData.page,
+        limit: currentData.limit,
+        total: currentData.total,
+        totalPages: currentData.totalPages,
+      }
+    : {
+        page,
+        limit: TEST_SCENARIO_PAGE_LIMIT,
+        total: 0,
+        totalPages: 0,
+      };
+  const isLoading = isQueryLoading || (isFetching && !currentData);
+  const onPageChange = useCallback((nextPage: number) => setPage(nextPage), []);
+
+  return {
+    scenarios,
+    pagination,
+    isLoading,
+    error,
+    onPageChange,
+  };
+};
+

--- a/src/components/test-scenarios/index.ts
+++ b/src/components/test-scenarios/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './components';
+export * from './containers';
+export * from './constants';
+export * from './hooks';
+export * from './types';
+export * from './utils';
+

--- a/src/components/test-scenarios/types.ts
+++ b/src/components/test-scenarios/types.ts
@@ -1,0 +1,14 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TestScenario, TestScenarioListResponse } from '@/redux/apis/generatedApi';
+
+export type TestScenarioSummary = Pick<TestScenario, 'id' | 'title' | 'createdAt' | 'updatedAt'>;
+
+export interface TestScenarioPagination {
+  page: TestScenarioListResponse['page'];
+  limit: TestScenarioListResponse['limit'];
+  total: TestScenarioListResponse['total'];
+  totalPages: TestScenarioListResponse['totalPages'];
+}
+

--- a/src/components/test-scenarios/utils.ts
+++ b/src/components/test-scenarios/utils.ts
@@ -1,0 +1,19 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TestScenario } from '@/redux/apis/generatedApi';
+
+import type { TestScenarioSummary } from './types';
+
+export const mapTestScenarioToSummary = (
+  scenario: Pick<TestScenario, 'id' | 'title' | 'createdAt' | 'updatedAt'>,
+): TestScenarioSummary => {
+  const { id, title, createdAt, updatedAt } = scenario;
+
+  return { id, title, createdAt, updatedAt };
+};
+
+export const mapTestScenariosToSummaries = (
+  scenarios: Pick<TestScenario, 'id' | 'title' | 'createdAt' | 'updatedAt'>[],
+): TestScenarioSummary[] => scenarios.map(mapTestScenarioToSummary);
+

--- a/src/components/ui/components/NavigationMenu/NavigationMenu.tsx
+++ b/src/components/ui/components/NavigationMenu/NavigationMenu.tsx
@@ -26,7 +26,7 @@ export const NavigationMenu = ({ collapsed }: { collapsed: boolean }) => {
                 : item.active;
               return (
                 <Box key={item.id} asChild>
-                  <Link to={item.path!}>
+                  <Link to={item.path!} aria-current={isActive ? 'page' : undefined}>
                     <NavItem icon={item.icon} label={item.label} collapsed={collapsed} active={isActive} />
                   </Link>
                 </Box>

--- a/src/components/ui/components/NavigationMenu/config.ts
+++ b/src/components/ui/components/NavigationMenu/config.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 VENSOLUTIONSGROUP LTD
 // SPDX-License-Identifier: Apache-2.0
 
-import { FiGrid, FiFileText, FiAlertTriangle, FiMessageSquare, FiCode, FiSettings } from 'react-icons/fi';
+import { FiGrid, FiFileText, FiAlertTriangle, FiMessageSquare, FiCode, FiSettings, FiClipboard } from 'react-icons/fi';
 
 import { PATHS } from '@/types/paths';
 
@@ -15,6 +15,7 @@ export const navigationMenuConfig: NavigationMenuGroup[] = [
       { id: 'dashboard', icon: FiGrid, label: 'Dashboard', path: PATHS.DASHBOARD },
       { id: 'results', icon: FiFileText, label: 'Results', path: PATHS.RESULTS, active: true },
       { id: 'issues', icon: FiAlertTriangle, label: 'Issues', path: PATHS.ISSUES },
+      { id: 'test-scenarios', icon: FiClipboard, label: 'Test Scenarios', path: PATHS.TEST_SCENARIOS },
       { id: 'prompts', icon: FiMessageSquare, label: 'Prompts', path: PATHS.PROMPTS },
       { id: 'skills', icon: FiCode, label: 'Skills', path: PATHS.SKILLS },
       // { id: 'report-generator', icon: FiPieChart, label: 'Report Generator', path: PATHS.REPORT_GENERATOR },

--- a/src/pages/TestScenarios/TestScenariosPage.tsx
+++ b/src/pages/TestScenarios/TestScenariosPage.tsx
@@ -1,0 +1,14 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+import { TestScenarioCatalog } from '@/components/test-scenarios';
+import { MainTemplate } from '@/components/ui/components/Templates/MainTemplate';
+
+export function TestScenariosPage() {
+  return (
+    <MainTemplate pageHeader="Test Scenarios">
+      <TestScenarioCatalog />
+    </MainTemplate>
+  );
+}
+

--- a/src/pages/TestScenarios/index.tsx
+++ b/src/pages/TestScenarios/index.tsx
@@ -1,0 +1,5 @@
+// Copyright 2026 VENSOLUTIONSGROUP LTD
+// SPDX-License-Identifier: Apache-2.0
+
+export { TestScenariosPage } from './TestScenariosPage';
+

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -9,6 +9,7 @@ export { PromptBuilderPage } from './PromptBuilder';
 export { PromptsPage } from './Prompts';
 export { ReportGeneratorPage } from './ReportGenerator';
 export { ResultsPage } from './Results';
+export { TestScenariosPage } from './TestScenarios';
 export { SkillDetailsPage } from './SkillDetails';
 export { SkillsPage } from './Skills';
 export { SignupPage } from './Signup';

--- a/src/redux/apis/generatedApi.ts
+++ b/src/redux/apis/generatedApi.ts
@@ -20,6 +20,7 @@ export const addTagTypes = [
   "CTRF",
   "Upload API Keys",
   "Exports",
+  "Test Scenarios",
 ] as const;
 const injectedRtkApi = api
   .enhanceEndpoints({
@@ -808,6 +809,139 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ["Reports", "Exports"],
       }),
+      postApiV2TestScenariosByScenarioIdSpecLinks: build.mutation<
+        PostApiV2TestScenariosByScenarioIdSpecLinksApiResponse,
+        PostApiV2TestScenariosByScenarioIdSpecLinksApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/v2/test-scenarios/${queryArg.scenarioId}/spec-links`,
+          method: "POST",
+          body: queryArg.testScenarioSpecLinkBody,
+          params: {
+            projectId: queryArg.projectId,
+          },
+        }),
+        invalidatesTags: ["Test Scenarios"],
+      }),
+      getApiV2TestScenariosByScenarioIdSpecLinks: build.query<
+        GetApiV2TestScenariosByScenarioIdSpecLinksApiResponse,
+        GetApiV2TestScenariosByScenarioIdSpecLinksApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/v2/test-scenarios/${queryArg.scenarioId}/spec-links`,
+          params: {
+            projectId: queryArg.projectId,
+            page: queryArg.page,
+            limit: queryArg.limit,
+          },
+        }),
+        providesTags: ["Test Scenarios"],
+      }),
+      patchApiV2TestScenariosByScenarioId: build.mutation<
+        PatchApiV2TestScenariosByScenarioIdApiResponse,
+        PatchApiV2TestScenariosByScenarioIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/v2/test-scenarios/${queryArg.scenarioId}`,
+          method: "PATCH",
+          body: queryArg.updateTestScenarioRequest,
+          params: {
+            projectId: queryArg.projectId,
+          },
+        }),
+        invalidatesTags: ["Test Scenarios"],
+      }),
+      getApiV2TestScenariosByScenarioId: build.query<
+        GetApiV2TestScenariosByScenarioIdApiResponse,
+        GetApiV2TestScenariosByScenarioIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/v2/test-scenarios/${queryArg.scenarioId}`,
+          params: {
+            projectId: queryArg.projectId,
+          },
+        }),
+        providesTags: ["Test Scenarios"],
+      }),
+      deleteApiV2TestScenariosByScenarioId: build.mutation<
+        DeleteApiV2TestScenariosByScenarioIdApiResponse,
+        DeleteApiV2TestScenariosByScenarioIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/v2/test-scenarios/${queryArg.scenarioId}`,
+          method: "DELETE",
+          params: {
+            projectId: queryArg.projectId,
+          },
+        }),
+        invalidatesTags: ["Test Scenarios"],
+      }),
+      deleteApiV2TestScenariosByScenarioIdSpecLinksAndSpecId: build.mutation<
+        DeleteApiV2TestScenariosByScenarioIdSpecLinksAndSpecIdApiResponse,
+        DeleteApiV2TestScenariosByScenarioIdSpecLinksAndSpecIdApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/v2/test-scenarios/${queryArg.scenarioId}/spec-links/${queryArg.specId}`,
+          method: "DELETE",
+          params: {
+            projectId: queryArg.projectId,
+          },
+        }),
+        invalidatesTags: ["Test Scenarios"],
+      }),
+      getApiV2TestScenariosByScenarioIdResults: build.query<
+        GetApiV2TestScenariosByScenarioIdResultsApiResponse,
+        GetApiV2TestScenariosByScenarioIdResultsApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/v2/test-scenarios/${queryArg.scenarioId}/results`,
+          params: {
+            projectId: queryArg.projectId,
+            page: queryArg.page,
+            limit: queryArg.limit,
+          },
+        }),
+        providesTags: ["Test Scenarios"],
+      }),
+      getApiV2TestScenariosByScenarioIdIssues: build.query<
+        GetApiV2TestScenariosByScenarioIdIssuesApiResponse,
+        GetApiV2TestScenariosByScenarioIdIssuesApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/v2/test-scenarios/${queryArg.scenarioId}/issues`,
+          params: {
+            projectId: queryArg.projectId,
+            page: queryArg.page,
+            limit: queryArg.limit,
+          },
+        }),
+        providesTags: ["Test Scenarios"],
+      }),
+      postApiV2TestScenarios: build.mutation<
+        PostApiV2TestScenariosApiResponse,
+        PostApiV2TestScenariosApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/v2/test-scenarios`,
+          method: "POST",
+          body: queryArg.createTestScenarioRequest,
+        }),
+        invalidatesTags: ["Test Scenarios"],
+      }),
+      getApiV2TestScenarios: build.query<
+        GetApiV2TestScenariosApiResponse,
+        GetApiV2TestScenariosApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/v2/test-scenarios`,
+          params: {
+            projectId: queryArg.projectId,
+            page: queryArg.page,
+            limit: queryArg.limit,
+          },
+        }),
+        providesTags: ["Test Scenarios"],
+      }),
     }),
     overrideExisting: false,
   });
@@ -1263,6 +1397,74 @@ export type PostApiV2ReportsPdfExportApiResponse =
   /** status 200 PDF export stream. When includeAiInsights is true, the PDF may include an AI Insights section embedded in the document. */ Blob;
 export type PostApiV2ReportsPdfExportApiArg = {
   pdfExportRequest: PdfExportRequest;
+};
+export type PostApiV2TestScenariosByScenarioIdSpecLinksApiResponse =
+  /** status 201 Test scenario Spec link created */ TestScenarioSpecLinkResponse;
+export type PostApiV2TestScenariosByScenarioIdSpecLinksApiArg = {
+  scenarioId: string;
+  projectId: string;
+  testScenarioSpecLinkBody: TestScenarioSpecLinkBody;
+};
+export type GetApiV2TestScenariosByScenarioIdSpecLinksApiResponse =
+  /** status 200 Paginated linked Specs */ TestScenarioSpecLinkListResponse;
+export type GetApiV2TestScenariosByScenarioIdSpecLinksApiArg = {
+  scenarioId: string;
+  projectId: string;
+  page?: number;
+  limit?: number;
+};
+export type PatchApiV2TestScenariosByScenarioIdApiResponse =
+  /** status 200 Updated test scenario details */ TestScenario;
+export type PatchApiV2TestScenariosByScenarioIdApiArg = {
+  scenarioId: string;
+  projectId: string;
+  updateTestScenarioRequest: UpdateTestScenarioRequest;
+};
+export type GetApiV2TestScenariosByScenarioIdApiResponse =
+  /** status 200 Test scenario details */ TestScenario;
+export type GetApiV2TestScenariosByScenarioIdApiArg = {
+  scenarioId: string;
+  projectId: string;
+};
+export type DeleteApiV2TestScenariosByScenarioIdApiResponse = unknown;
+export type DeleteApiV2TestScenariosByScenarioIdApiArg = {
+  scenarioId: string;
+  projectId: string;
+};
+export type DeleteApiV2TestScenariosByScenarioIdSpecLinksAndSpecIdApiResponse =
+  unknown;
+export type DeleteApiV2TestScenariosByScenarioIdSpecLinksAndSpecIdApiArg = {
+  scenarioId: string;
+  specId: string;
+  projectId: string;
+};
+export type GetApiV2TestScenariosByScenarioIdResultsApiResponse =
+  /** status 200 Paginated scenario Result evidence */ TestScenarioResultsResponse;
+export type GetApiV2TestScenariosByScenarioIdResultsApiArg = {
+  scenarioId: string;
+  projectId: string;
+  page?: number;
+  limit?: number;
+};
+export type GetApiV2TestScenariosByScenarioIdIssuesApiResponse =
+  /** status 200 Paginated scenario Issue evidence */ TestScenarioIssuesResponse;
+export type GetApiV2TestScenariosByScenarioIdIssuesApiArg = {
+  scenarioId: string;
+  projectId: string;
+  page?: number;
+  limit?: number;
+};
+export type PostApiV2TestScenariosApiResponse =
+  /** status 201 Test scenario created */ TestScenario;
+export type PostApiV2TestScenariosApiArg = {
+  createTestScenarioRequest: CreateTestScenarioRequest;
+};
+export type GetApiV2TestScenariosApiResponse =
+  /** status 200 Paginated test scenarios */ TestScenarioListResponse;
+export type GetApiV2TestScenariosApiArg = {
+  projectId: string;
+  page?: number;
+  limit?: number;
 };
 export type StatusResponse = {
   status: string;
@@ -2018,6 +2220,106 @@ export type PdfExportRequest = {
   /** When true, the export includes an AI-generated insights section in the PDF. Defaults to false when omitted. */
   includeAiInsights?: boolean;
 };
+export type TestScenarioSpecLinkResponse = {
+  scenarioId: string;
+  specId: string;
+};
+export type TestScenarioSpecLinkBody = {
+  specId: string;
+};
+export type TestScenarioLinkedSpec = {
+  id: string;
+  projectId: string;
+  key: string;
+  file: string;
+  title: string;
+  tags: string[];
+  annotations: any[];
+  createdAt: string;
+  updatedAt: string;
+};
+export type TestScenarioSpecLinkListResponse = {
+  scenarioId: string;
+  projectId: string;
+  specs: TestScenarioLinkedSpec[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+};
+export type TestScenario = {
+  id: string;
+  projectId: string;
+  createdById: string;
+  title: string;
+  contentMd: string;
+  createdAt: string;
+  updatedAt: string;
+};
+export type UpdateTestScenarioRequest =
+  | {
+      title: string;
+      contentMd?: string;
+    }
+  | {
+      title?: string;
+      contentMd: string;
+    };
+export type TestScenarioResultsResponse = {
+  scenarioId: string;
+  projectId: string;
+  linkedSpecCount: number;
+  results: Result[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+};
+export type TestScenarioObservedIssue = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  name: string;
+  category: string;
+  description: string | null;
+  portal: string | null;
+  service: string | null;
+  ticket: string | null;
+  createdBy: {
+    id: string;
+    name: string;
+    email: string;
+    createdAt: string;
+  } | null;
+  updatedBy: {
+    id: string;
+    name: string;
+    email: string;
+    createdAt: string;
+  } | null;
+};
+export type TestScenarioIssuesResponse = {
+  scenarioId: string;
+  projectId: string;
+  linkedSpecCount: number;
+  issues: TestScenarioObservedIssue[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+};
+export type CreateTestScenarioRequest = {
+  projectId: string;
+  title: string;
+  contentMd: string;
+};
+export type TestScenarioListResponse = {
+  scenarios: TestScenario[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+};
 export const {
   useGetApiV2StatusQuery,
   useLazyGetApiV2StatusQuery,
@@ -2116,4 +2418,19 @@ export const {
   useGetApiV2AnalysisExportQuery,
   useLazyGetApiV2AnalysisExportQuery,
   usePostApiV2ReportsPdfExportMutation,
+  usePostApiV2TestScenariosByScenarioIdSpecLinksMutation,
+  useGetApiV2TestScenariosByScenarioIdSpecLinksQuery,
+  useLazyGetApiV2TestScenariosByScenarioIdSpecLinksQuery,
+  usePatchApiV2TestScenariosByScenarioIdMutation,
+  useGetApiV2TestScenariosByScenarioIdQuery,
+  useLazyGetApiV2TestScenariosByScenarioIdQuery,
+  useDeleteApiV2TestScenariosByScenarioIdMutation,
+  useDeleteApiV2TestScenariosByScenarioIdSpecLinksAndSpecIdMutation,
+  useGetApiV2TestScenariosByScenarioIdResultsQuery,
+  useLazyGetApiV2TestScenariosByScenarioIdResultsQuery,
+  useGetApiV2TestScenariosByScenarioIdIssuesQuery,
+  useLazyGetApiV2TestScenariosByScenarioIdIssuesQuery,
+  usePostApiV2TestScenariosMutation,
+  useGetApiV2TestScenariosQuery,
+  useLazyGetApiV2TestScenariosQuery,
 } = injectedRtkApi;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -17,6 +17,7 @@ import {
   SkillDetailsPage,
   SkillsPage,
   SignupPage,
+  TestScenariosPage,
   UserSettingsPage,
 } from '@/pages';
 import { MCPSettings } from '@/pages/UserSettings/MCPSettings';
@@ -96,6 +97,17 @@ export const router = createBrowserRouter([
       <ProtectedRoute>
         <ProjectGuard>
           <IssuesPage />
+        </ProjectGuard>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: PATHS.TEST_SCENARIOS,
+    errorElement: <RouterErrorFallback />,
+    element: (
+      <ProtectedRoute>
+        <ProjectGuard>
+          <TestScenariosPage />
         </ProjectGuard>
       </ProtectedRoute>
     ),

--- a/src/types/paths.ts
+++ b/src/types/paths.ts
@@ -6,6 +6,7 @@ export enum PATHS {
   DASHBOARD = '/dashboard',
   RESULTS = '/results',
   ISSUES = '/issues',
+  TEST_SCENARIOS = '/test-scenarios',
   SKILLS = '/skills',
   SKILL_DETAILS = '/skills/:id',
   LOGIN = '/login',


### PR DESCRIPTION
## Summary

- Add a protected, project-scoped Test Scenarios catalog at `/test-scenarios`
- Generate the authenticated RTK Query Test Scenario contract
- Add summary table, pagination, project-switch isolation, navigation, route guards, and focused tests
- Update the OpenSpec change artifacts

## Verification

- `yarn test` — 44 files, 149 tests passed
- `yarn lint`
- `yarn tsc`
- `yarn build`
- `openspec validate add-project-scoped-test-scenario-list --type change --strict`
- `git diff --check`

## Dependency

The catalog consumes the backend Test Scenario REST endpoints; coordinate delivery with the backend branch exposing `/api/v2/test-scenarios`.